### PR TITLE
Correct suite key

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -7,11 +7,11 @@
   "url": "http://fsl.fmrib.ox.ac.uk/fsl/fslwiki/BET",
   "source": "https://github.com/scitran-apps/fsl-bet",
   "license": "Apache-2.0",
-  "flywheel": {
-    "suite": "FSL"
-  },
-  "version": "0.2.0",
+  "version": "0.2.1",
   "custom": {
+      "flywheel": {
+        "suite": "FSL"
+      },
     "docker-image": "scitran/fsl-bet:0.2.0"
   },
   "config": {


### PR DESCRIPTION
The 0.2.0 version of this gear had this layout for its suite key:

```json
"flywheel": {
  "suite": "FSL"
},
"version": "0.2.0",
"custom": {
  "docker-image": "scitran/fsl-bet:0.2.0"
},
```

This was tripping up the Go SDK, which expects `flywheel` to be a string. To specify a suite, the manifest key [needs to be](https://github.com/flywheel-io/gears/tree/master/spec#reserved-custom-keys) `custom.flywheel.suite` instead, otherwise it won't group with other FSL gears in the frontend.

I've bumped the version to `0.2.1`, is there anything else that I should do to cut a new version?